### PR TITLE
Add Semicolon Spacing Sniff

### DIFF
--- a/PhoneBurner/ruleset.xml
+++ b/PhoneBurner/ruleset.xml
@@ -198,4 +198,7 @@
     </rule>
 
     <rule ref="Generic.PHP.RequireStrictTypes"/>
+
+    <!-- Prohibit extra spaces around and semicolons -->
+    <rule ref="Squiz.Whitespace.SemicolonSpacing"/>
 </ruleset>


### PR DESCRIPTION
Adds the "Squiz.Whitespace.SemicolonSpacing", prohibiting extra whitespace around semicolons.

Important: merge _after_ https://github.com/phoneburner/salt/pull/27138 to prevent the potential for existing PRs to fail CI on updated rules (should not happen, but worth waiting)
